### PR TITLE
fix: wrong comment of incrementByTen in Closures

### DIFF
--- a/swift/Closures.md
+++ b/swift/Closures.md
@@ -132,7 +132,7 @@ let incrementByTen = makeIncrementer(forIncrement: 10)
 incrementByTen()
 incrementByTen()
 incrementByTen()
-// returns a value of 39
+// returns a value of 30
 ```
 
 And by calling it three times it would return a value of 30.


### PR DESCRIPTION
[Problem]
Comment is not matched to the description.

<img width="432" alt="스크린샷 2023-10-31 오후 3 22 47" src="https://github.com/jrasmusson/ios-starter-kit/assets/16129260/4f2f40a8-67e9-4a58-809b-caa60270c764">
