### PR TITLE
Fix Wrong Description and Indentation of UIStackView Basic

### DIFF
--- a/basics/UIStackView/Basics/README.md
+++ b/basics/UIStackView/Basics/README.md
@@ -352,10 +352,10 @@ But what we are missing is the hugging and compression necessary to tell autolay
 
 <img src="https://github.com/jrasmusson/ios-starter-kit/blob/master/basics/UIStackView/Basics/images/chart.png" alt="drawing" width="600"/>
 
-    Usually in this situation we want the label to hold it's intrinsic width, 
-    and have the text field expand. 
-    So we **increase** the `UILabel` horizontal and vertical **hugging**,
-    while **decreasing** the `UITextField` hugging and horizontal resistance.
+Usually in this situation we want the label to hold it's intrinsic width, 
+and have the text field expand. 
+So we **increase** the `UILabel` horizontal and vertical **hugging**,
+while **decreasing** the `UITextField` hugging and horizontal resistance.
 
 <img src="https://github.com/jrasmusson/ios-starter-kit/blob/master/basics/UIStackView/Basics/images/hugging-added.png" alt="drawing" width="400"/>
 
@@ -443,7 +443,7 @@ class ViewController: UIViewController {
             nameRowsStack.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
             nameRowsStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             nameRowsStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            ])
+        ])
 
     }
 
@@ -497,15 +497,15 @@ In this case you can get your images to align by changing you stack view alignme
 
 ```swift
 func makeNameStackView() -> UIStackView {
-        let stack = UIStackView()
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        stack.axis = .horizontal
-        stack.distribution = .fill
-        stack.alignment = .center // gets them aligned
-        stack.spacing = 8.0
+    let stack = UIStackView()
+    stack.translatesAutoresizingMaskIntoConstraints = false
+    stack.axis = .horizontal
+    stack.distribution = .fill
+    stack.alignment = .center // gets them aligned
+    stack.spacing = 8.0
 
-        return stack
-    }
+    return stack
+}
 ```
 
 And then making the images themselves `scaleAspectFit`


### PR DESCRIPTION
Indentation makes description to a block?
<img width="666" alt="스크린샷 2023-11-23 오후 2 05 54" src="https://github.com/jrasmusson/ios-starter-kit/assets/16129260/6525e187-fcce-4814-bda7-3478c13a81d1">

<img width="270" alt="스크린샷 2023-11-23 오후 2 06 11" src="https://github.com/jrasmusson/ios-starter-kit/assets/16129260/85b0f1c6-2aa2-48b0-a4fa-8087ea80506f">

<img width="375" alt="스크린샷 2023-11-23 오후 2 06 22" src="https://github.com/jrasmusson/ios-starter-kit/assets/16129260/218a4398-6593-4bec-a86b-2e37a1ba402d">
