### PR TITLE
Fix double `of` of mvvm

### DIFF
--- a/advanced/MVVM/MVVM.md
+++ b/advanced/MVVM/MVVM.md
@@ -1,6 +1,6 @@
 # MVVM
 
-MVVM is a variation of MVC where we pull presentation and business logic out of of `ViewController` and stick it in something called a `ViewModel`
+MVVM is a variation of MVC where we pull presentation and business logic out of `ViewController` and stick it in something called a `ViewModel`
 
 MVVC
 


### PR DESCRIPTION
Removes the duplicated `of`
<img width="344" alt="스크린샷 2023-11-29 오후 1 41 53" src="https://github.com/jrasmusson/ios-starter-kit/assets/16129260/986367c0-1230-4c46-a222-7d36452ad985">
