### PR TITLE
Fix the wrong method call of ChatNotifier

### DIFF
--- a/testing/testing-with-callbacks.md
+++ b/testing/testing-with-callbacks.md
@@ -91,7 +91,7 @@ class ChatNotifierSpec: QuickSpec {
                     let chatNotifier = ChatNotifier(notificationPermissionPromptStatus: NotificationPermissionPromptStatus.notShown,
                                                     notShownHandler: showScreen,
                                                     shownAndDeniedHandler: showAlert)
-                    chatNotifier.call()
+                    chatNotifier.notify()
                 }
 
                 it("should show screen") {


### PR DESCRIPTION
I couldn't find out the method `call`
<img width="310" alt="스크린샷 2023-12-01 오후 1 51 24" src="https://github.com/jrasmusson/ios-starter-kit/assets/16129260/32f2b16e-765e-4f4e-a599-f0d52a0add3b">

And I am curious why there is no code to reset `havePromptedUserForNotifications`.
I guess `havePromptedUserForNotifications` should be rollbacked to false by beforeEach.
